### PR TITLE
Skip gunzip when in check mode

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -10,14 +10,14 @@
      register: download_geolite
      tags:
          - geoip
-   
+
    - name: Ensure that GeoIP folder exists
      file: "path={{ geo_ip_folder }} state=directory mode=0755"
      tags:
          - geoip
-   
+
    - name: Unpack GeoLite database
      shell: "gunzip {{download_geolite.dest}} && mv /tmp/GeoLiteCity.dat {{ geo_ip_folder }}/"
+     when: not ansible_check_mode
      tags:
          - geoip
-   


### PR DESCRIPTION
Quick update to skip unpack during check mode; since get_url already skips the variable is undefined.